### PR TITLE
Aggiunta nota sull'helpdesk per i cittadini

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,8 @@
 <img src="https://github.com/italia/spid-graphics/blob/master/spid-logos/spid-logo-b-lb.png" alt="SPID" data-canonical-src="https://github.com/italia/spid-graphics/blob/master/spid-logos/spid-logo-b-lb.png" width="500" height="98" />
 
-**SPID**, il Sistema Pubblico di Identità Digitale, è la soluzione che ti permette di accedere a tutti i servizi online della Pubblica Amministrazione con un'unica Identità Digitale (username e password) utilizzabile da computer, tablet e smartphone.
-
-> **[Sito informativo www.spid.gov.it](https://www.spid.gov.it)**<br>
-> Il sito è rivolto principalmente ai cittadini e li guida e supporta per l'ottenimento dell'Identità Digitale SPID
-
-
-> **[Sezione SPID AgID](http://www.agid.gov.it/agenda-digitale/infrastrutture-architetture/spid)**<br>
-> In questa sezione del sito AgID sono disponibili le versioni ufficiali dei regolamenti attuativi, regole tecniche e avvisi
-
-
-> **[Sezione SPID di Developers Italia](https://developers.italia.it/it/spid)**<br>
-> In Developers Italia, sezione SPID, sono presenti le versioni non ufficiali e consolidate di regolamenti attuativi, regole tecniche oltre che guide e risorse applicative ufficiali SPID manutenute da AgID.
-
-
 ## Supporto Tecnico SPID
+
+> **NOTA BENE: Questo non è un canale di supporto per i cittadini**, ma è riservato agli sviluppatori e ai gestori di servizi (pubbliche amministrazioni ed enti privati). Per l'assistenza ai cittadini si prega di seguire le indicazioni presenti nel sito [www.spid.gov.it](https://www.spid.gov.it/serve-aiuto).
 
 Il servizio di supporto tecnico SPID utilizza le issue di Github per permettere la condivisione delle soluzioni e discussioni tecniche e consentire alla community di cooperare.<br>
 Per utilizzare il supporto tecnico SPID potete fare riferimento alla **[guida](https://github.com/italia/spid/blob/master/HOWTO.md)**.
@@ -41,3 +29,12 @@ Le persone che rispondono per conto di AgID - Agenzia per l'Italia Digitale sono
 
 ## Importante
 Per favore, **non inserire dati ritenuti sensibili e nessun dato relativo a configurazioni di sicurezza, quali certificati o password...***; se si deve inviare un tracciato, altri dati sensibili o configurazioni di sicurezza, aprire una issue su GitHub e, successivamente, inviare i dati via email a [spid.tech@agid.gov.it](mailto:spid.tech@agid.gov.it) specificando nell'oggetto della e-mail il numero della issue GitHub creata. L'email può essere usata solamente per inviare allegati o indicare gli indirizzi per la validazione del servizio ed eventuali istruzioni di collegamento, ulteriori commenti nel corpo della email verranno ignorati.
+
+## Link utili
+
+* **[Sezione SPID di AgID](http://www.agid.gov.it/agenda-digitale/infrastrutture-architetture/spid)**<br>
+In questa sezione del sito AgID sono disponibili le versioni ufficiali dei regolamenti attuativi, regole tecniche e avvisi.
+
+* **[Sezione SPID di Developers Italia](https://developers.italia.it/it/spid)**<br>
+In Developers Italia, sezione SPID, sono presenti le versioni non ufficiali e consolidate di regolamenti attuativi, regole tecniche oltre che guide e risorse applicative ufficiali SPID manutenute da AgID.
+


### PR DESCRIPTION
Propongo questa modifica per chiarire che non è un canale di supporto per i cittadini. Ho semplificato il testo rendendolo più mirato al target di riferimento (sviluppatori e SP).